### PR TITLE
Update EasyRecovery.sh

### DIFF
--- a/EasyRecovery.sh
+++ b/EasyRecovery.sh
@@ -1,20 +1,19 @@
 #!/bin/sh
 # Unix OS Sniffer and $adb setup by Firon
 platform=`uname`;
-ADB=$PWD"/Files/tools/adb";
-FASTBOOT=$PWD"/Files/tools/fastboot";
-MFASTBOOT=$PWD"/Files/tools/mfastboot";
+ADB=$(which adb);
+FASTBOOT=$(which fastboot);
+MFASTBOOT=$(which mfastboot);
 cd "$(dirname "$0")"
 if [ -z $(which adb) ]; then
-	ADB=$PWD"/Files/tools/adb";
+    ADB=$PWD"/Files/tools/adb";
     FASTBOOT=$PWD"/Files/tools/fastboot";
     MFASTBOOT=$PWD"/Files/tools/mfastboot";
-	if [ "$platform" == 'Darwin' ]; then
-		ADB=$PWD"/Files/tools/adb.osx"
-		FASTBOOT=$PWD"/Files/tools/fastboot.osx"
+    if [ "$platform" == 'Darwin' ]; then
+        ADB=$PWD"/Files/tools/adb.osx"
+        FASTBOOT=$PWD"/Files/tools/fastboot.osx"
         MFASTBOOT=$PWD"/Files/tools/mfastboot.osx";
-
-	fi
+    fi
 fi
 chmod +x $ADB
 chmod +x $FASTBOOT


### PR DESCRIPTION
I installed fastboot and adb and it didn't worked because  $ADB was /Files/tools/fastboot/ which was wrong for osx and platform darwin.
It's now $(which adb) first (or empty if not found) and will be replaced with /Files/ when empty. It's not the very best way now, but it's working
